### PR TITLE
Add NET_ADMIN, NET_RAW

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ docker run --name wyl \
 	-e "IFACES=$YOURIFACE" \
 	-e "TZ=$YOURTIMEZONE" \
 	--network="host" \
+	--cap-add=NET_ADMIN --cap-add=NET_RAW \
 	-v $DOCKERDATAPATH/wyl:/data/WatchYourLAN \
     aceberg/watchyourlan:v2
 ```
@@ -156,6 +157,7 @@ docker run --name wyl \
 	-e "IFACES=$YOURIFACE" \
 	-e "TZ=$YOURTIMEZONE" \
 	--network="host" \
+	--cap-add=NET_ADMIN --cap-add=NET_RAW \
 	-v $DOCKERDATAPATH/wyl:/data/WatchYourLAN \
     aceberg/watchyourlan:v2 -n "http://$YOUR_IP:8850"
 ```


### PR DESCRIPTION
Container wasn't able to capture on the interfaces: 

```
/app # /usr/bin/arp-scan -glNx -I end0
pcap_activate: end0: You don't have permission to perform this capture on that device
(socket: Operation not permitted)
/app # /usr/bin/arp-scan -glNx -I wlan0
pcap_activate: wlan0: You don't have permission to perform this capture on that device
(socket: Operation not permitted)
/app # whoami
root
```


Adding NET_RAW and NET_ADMIN fixes this

https://github.com/aceberg/WatchYourLAN/issues/106