### PR TITLE
Changed to clear previous results when starting port scan

### DIFF
--- a/internal/web/public/js/host-scan.js
+++ b/internal/web/public/js/host-scan.js
@@ -9,6 +9,8 @@ async function scanAddr() {
     let begin = document.getElementById("begin").value;
     let end = document.getElementById("end").value;
 
+    document.getElementById('foundPorts').innerHTML = "";
+
     if (begin == "") {
         begin = 1
     }


### PR DESCRIPTION
Improve to clear the previous result since the first result is followed by two or more port scans.
As a result, only the result of the most recent one scan will be displayed.

https://github.com/user-attachments/assets/fced551c-1731-4eb4-9d3d-f77196985b89