### PR TITLE
Add FirstSeen attribute

### DIFF
--- a/internal/db/edit.go
+++ b/internal/db/edit.go
@@ -10,30 +10,32 @@ import (
 func Create() {
 
 	sqlStatement := `CREATE TABLE IF NOT EXISTS "now" (
-		"ID"	` + currentDB.PrimaryKey + `,
-		"NAME"	TEXT NOT NULL,
-		"DNS"	TEXT NOT NULL,
-		"IFACE"	TEXT,
-		"IP"	TEXT,
-		"MAC"	TEXT,
-		"HW"	TEXT,
-		"DATE"	TEXT,
-		"KNOWN"	INTEGER DEFAULT 0,
-		"NOW"	INTEGER DEFAULT 0
+		"ID"	    ` + currentDB.PrimaryKey + `,
+		"NAME"	    TEXT NOT NULL,
+		"DNS"	    TEXT NOT NULL,
+		"IFACE"	    TEXT,
+		"IP"	    TEXT,
+		"MAC"	    TEXT,
+		"HW"	    TEXT,
+		"DATE"	    TEXT,
+		"FIRSTSEEN" TEXT,
+		"KNOWN"	    INTEGER DEFAULT 0,
+		"NOW"	    INTEGER DEFAULT 0
 	);`
 	dbExec(sqlStatement)
 
 	sqlStatement = `CREATE TABLE IF NOT EXISTS "history" (
-		"ID"	` + currentDB.PrimaryKey + `,
-		"NAME"	TEXT NOT NULL,
-		"DNS"	TEXT NOT NULL,
-		"IFACE"	TEXT,
-		"IP"	TEXT,
-		"MAC"	TEXT,
-		"HW"	TEXT,
-		"DATE"	TEXT,
-		"KNOWN"	INTEGER DEFAULT 0,
-		"NOW"	INTEGER DEFAULT 0
+		"ID"	    ` + currentDB.PrimaryKey + `,
+		"NAME"	    TEXT NOT NULL,
+		"DNS"	    TEXT NOT NULL,
+		"IFACE"	    TEXT,
+		"IP"	    TEXT,
+		"MAC"	    TEXT,
+		"HW"	    TEXT,
+		"DATE"	    TEXT,
+		"FIRSTSEEN" TEXT,
+		"KNOWN"	    INTEGER DEFAULT 0,
+		"NOW"	    INTEGER DEFAULT 0
 	);`
 	dbExec(sqlStatement)
 }
@@ -42,8 +44,8 @@ func Create() {
 func Insert(table string, oneHost models.Host) {
 	oneHost.Name = quoteStr(oneHost.Name)
 	oneHost.Hw = quoteStr(oneHost.Hw)
-	sqlStatement := `INSERT INTO %s ("NAME", "DNS", "IFACE", "IP", "MAC", "HW", "DATE", "KNOWN", "NOW") VALUES ('%s','%s','%s','%s','%s','%s','%s','%d','%d');`
-	sqlStatement = fmt.Sprintf(sqlStatement, table, oneHost.Name, oneHost.DNS, oneHost.Iface, oneHost.IP, oneHost.Mac, oneHost.Hw, oneHost.Date, oneHost.Known, oneHost.Now)
+	sqlStatement := `INSERT INTO %s ("NAME", "DNS", "IFACE", "IP", "MAC", "HW", "DATE", "FIRSTSEEN", "KNOWN", "NOW") VALUES ('%s','%s','%s','%s','%s','%s','%s','%s','%d','%d');`
+	sqlStatement = fmt.Sprintf(sqlStatement, table, oneHost.Name, oneHost.DNS, oneHost.Iface, oneHost.IP, oneHost.Mac, oneHost.Hw, oneHost.Date, oneHost.FirstSeen, oneHost.Known, oneHost.Now)
 
 	dbExec(sqlStatement)
 }

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -32,16 +32,17 @@ type Conf struct {
 
 // Host - one host
 type Host struct {
-	ID    int    `db:"ID"`
-	Name  string `db:"NAME"`
-	DNS   string `db:"DNS"`
-	Iface string `db:"IFACE"`
-	IP    string `db:"IP"`
-	Mac   string `db:"MAC"`
-	Hw    string `db:"HW"`
-	Date  string `db:"DATE"`
-	Known int    `db:"KNOWN"`
-	Now   int    `db:"NOW"`
+	ID        int    `db:"ID"`
+	Name      string `db:"NAME"`
+	DNS       string `db:"DNS"`
+	Iface     string `db:"IFACE"`
+	IP        string `db:"IP"`
+	Mac       string `db:"MAC"`
+	Hw        string `db:"HW"`
+	Date      string `db:"DATE"`
+	FirstSeen string `db:"FIRSTSEEN"`
+	Known     int    `db:"KNOWN"`
+	Now       int    `db:"NOW"`
 }
 
 // Stat - status

--- a/internal/web/public/js/index.js
+++ b/internal/web/public/js/index.js
@@ -31,6 +31,7 @@ function createHTML(addr, i) {
         <td><a href="/host/${addr.ID}">${addr.Mac}</a></td>
         <td>${addr.Hw}</td>
         <td>${addr.Date}</td>
+        <td>${addr.FirstSeen}</td>
         <td>
             <div class="form-check form-switch">
                 <input onclick="editForm(${addr.ID}, 'toggle')" class="form-check-input" type="checkbox" ${known}>

--- a/internal/web/scan-routine.go
+++ b/internal/web/scan-routine.go
@@ -76,6 +76,7 @@ func compareHosts(foundHosts []models.Host) {
 	for _, fHost := range foundHostsMap {
 
 		fHost.Name, fHost.DNS = updateDNS(fHost)
+		fHost.FirstSeen = time.Now().Format("2006-01-02 15:04:05")
 
 		msg := fmt.Sprintf("WatchYourLAN: unknown host found. Names: '%s', IP: '%s', MAC: '%s', Hw: '%s', Iface: '%s'", fHost.DNS, fHost.IP, fHost.Mac, fHost.Hw, fHost.Iface)
 		slog.Warn(msg)

--- a/internal/web/templates/host.html
+++ b/internal/web/templates/host.html
@@ -41,6 +41,10 @@
                 <td>{{ .Host.Date }}</td>
               </tr>
               <tr>
+                <td>First Seen</td>
+                <td>{{ .Host.FirstSeen }}</td>
+              </tr>
+              <tr>
                 <td>Known</td>
                 <td>{{ if eq .Host.Known 1 }}Yes{{ else }}No{{ end }}</td>
               </tr>

--- a/internal/web/templates/index.html
+++ b/internal/web/templates/index.html
@@ -53,6 +53,7 @@
               <th>MAC <i class="bi bi-sort-down-alt my-btn" onclick="sortBy('Mac')"></i></th>
               <th>Hardware <i class="bi bi-sort-down-alt my-btn" onclick="sortBy('Hw')"></i></th>
               <th>Date <i class="bi bi-sort-down-alt my-btn" onclick="sortBy('Date')"></i></th>
+              <th>First Seen <i class="bi bi-sort-down-alt my-btn" onclick="sortBy('FirstSeen')"></i></th>
               <th>Known <i class="bi bi-sort-down-alt my-btn" onclick="sortBy('Known')"></i></th>
               <th>Online <i class="bi bi-sort-down-alt my-btn" onclick="sortBy('Now')"></i></th>
             </thead>


### PR DESCRIPTION
This adds a new date attribute called "First Seen" which is simply a datestamp of when the host was initially discovered. 

This is particularly useful if you're using this tool to identify something which has newly been added to the network.

I've tested this locally in a brand new container and it works fine - however given there's no altering mechanism in place it would require any existing users to manually update their db tables or delete and start from scratch.