### PR TITLE
Add NET_ADMIN, NET_RAW, remove obsolete docker compose "version" attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ docker run --name wyl \
 	-e "IFACES=$YOURIFACE" \
 	-e "TZ=$YOURTIMEZONE" \
 	--network="host" \
+	--cap-add=NET_ADMIN --cap-add=NET_RAW \
 	-v $DOCKERDATAPATH/wyl:/data/WatchYourLAN \
     aceberg/watchyourlan
 ```
@@ -180,12 +181,13 @@ docker run --name wyl \
 	-e "IFACES=$YOURIFACE" \
 	-e "TZ=$YOURTIMEZONE" \
 	--network="host" \
+	--cap-add=NET_ADMIN --cap-add=NET_RAW \
 	-v $DOCKERDATAPATH/wyl:/data/WatchYourLAN \
     aceberg/watchyourlan -n "http://$YOUR_IP:8850"
 ```
 Or use [docker-compose](docker-compose-local.yml)
 
-</details> 
+</details>
 
 ## API & Integrations
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,10 @@
-version: "3"
 services:
   wyl:
     image: aceberg/watchyourlan
-    network_mode: "host"        
+    network_mode: "host"
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
     restart: unless-stopped
     volumes:
     - ~/.dockerdata/wyl:/data/WatchYourLAN


### PR DESCRIPTION
Fixes #106 for Linux users (#107 looks abandoned)
Also removed the obsolete "version" docker compose attribute 
![image](https://github.com/user-attachments/assets/b20716df-9382-4058-ab76-1670f002754e)
