### PR TITLE
Remove `time/tzdata` dependency

### DIFF
--- a/cmd/WatchYourLAN/main.go
+++ b/cmd/WatchYourLAN/main.go
@@ -5,7 +5,6 @@ import (
 	// "net/http"
 
 	// _ "net/http/pprof"
-	_ "time/tzdata"
 
 	"github.com/aceberg/WatchYourLAN/internal/web"
 )


### PR DESCRIPTION
This PR removes the `time/tzdata` import. This package is not necessary if the system has the `tzdata` package, and this repo installs it [during the Docker build](https://github.com/aceberg/WatchYourLAN/blob/a3d86cb7d765bda7faae49d8f3aaeb490ff37bac/Dockerfile#L12). The system's `tzdata` package can be updated without requiring a Go build, and removing this package will decrease the size of the program by [about 450 KB](https://github.com/aceberg/WatchYourLAN/blob/a3d86cb7d765bda7faae49d8f3aaeb490ff37bac/Dockerfile#L12).