### PR TITLE
Build a smaller Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:alpine AS builder
 
 RUN apk add build-base
 COPY . /src
-RUN cd /src/cmd/WatchYourLAN/ && CGO_ENABLED=0 go build -o /WatchYourLAN .
+RUN cd /src/cmd/WatchYourLAN/ && CGO_ENABLED=0 go build -ldflags='-w -s' -o /WatchYourLAN .
 
 
 FROM alpine


### PR DESCRIPTION
This PR adds `-ldflags='-w -s'` to the Docker build. This strips debug information from the resulting binary, shaving 9 MB off of the image size (from 38 MB to 29 MB). GoRelease builds do this by default, but the flag is currently missing from the Docker builds.