### PR TITLE
Optimize Docker build

### DIFF
--- a/.github/workflows/main-docker-all.yml
+++ b/.github/workflows/main-docker-all.yml
@@ -57,3 +57,5 @@ jobs:
             ghcr.io/${{ secrets.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:v2
             ghcr.io/${{ secrets.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:latest
             ghcr.io/${{ secrets.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:alpine AS builder
 
 RUN apk add build-base
 COPY . /src
-RUN cd /src/cmd/WatchYourLAN/ && CGO_ENABLED=0 go build -o /WatchYourLAN .
+RUN cd /src/cmd/WatchYourLAN/ && CGO_ENABLED=0 go build -ldflags='-w -s' -o /WatchYourLAN .
 
 
 FROM alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,18 @@
-FROM golang:alpine AS builder
+FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx
 
-RUN apk add build-base
+FROM --platform=$BUILDPLATFORM golang:alpine AS builder
+
+COPY --from=xx / /
 
 WORKDIR /src
-COPY go.mod go.sum .
+
+COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-WORKDIR /src/cmd/WatchYourLAN
-RUN CGO_ENABLED=0 go build -ldflags='-w -s' -o /WatchYourLAN .
+
+ARG TARGETPLATFORM
+RUN CGO_ENABLED=0 xx-go build -ldflags='-w -s' -o /WatchYourLAN ./cmd/WatchYourLAN
 
 
 FROM alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
 FROM golang:alpine AS builder
 
 RUN apk add build-base
-COPY . /src
-RUN cd /src/cmd/WatchYourLAN/ && CGO_ENABLED=0 go build -ldflags='-w -s' -o /WatchYourLAN .
+
+WORKDIR /src
+COPY go.mod go.sum .
+RUN go mod download
+
+COPY . .
+WORKDIR /src/cmd/WatchYourLAN
+RUN CGO_ENABLED=0 go build -ldflags='-w -s' -o /WatchYourLAN .
 
 
 FROM alpine


### PR DESCRIPTION
This PR speeds up the Docker build and decreases the final image size.

- 92f89bb3135e443132d1760834e0f4e9273950dc: Add `-ldflags='-w -s'` to the Go build command.
  - This strips debug information from the resulting binary, shaving 9 MB off of the image size (from 38 MB to 29 MB). GoReleaser builds do this by default, but the flag is currently missing from the Docker builds.
- 0b34f6181f61b7495db978d29210ca4f1837b2ac: Take advantage of Docker cache if dependencies have not changed.
  - Go dependencies are now downloaded in a separate `RUN` stage before all files are copied into the container. This allows for build cache to be used when the dependencies have not changed.
- a2fd352bf1b195eae5c775a813695314953e0210: GitHub Actions cache is used for the Docker build in the `Main-Docker` CI workflow.
- 93852060cc1e1f433861b9bd9a35869d926f83ce: Use native Go cross-compilation instead of QEMU.
  - This drastically increases the build speed because, while QEMU is a great tool, emulation is slow. Adding `--platform=$BUILDPLATFORM` to the `FROM` line makes Docker use the host's architecture and sets `TARGETPLATFORM` to the desired architecture. This allows for native Go cross-compilation without using emulation.

As a result, the final image is now smaller by 9 MB (from 38 MB to 29 MB), and build times should be about [4 minutes with no cache](https://github.com/gabe565/WatchYourLAN/actions/runs/13893311306) and [3 minutes with cache](https://github.com/gabe565/WatchYourLAN/actions/runs/13893371729).

Note that to set the correct `GOARCH` and `GOARM` envs, I used [tonistiigi/xx](https://github.com/tonistiigi/xx). The owner of that repo also maintains the images that `docker/setup-qemu-action` installs, so they are reputable. If you'd prefer to not add a build dependency, this could also be done using something like:
```sh
set -eux
case "$TARGETPLATFORM" in
  'linux/amd64') export GOARCH=amd64 ;;
  'linux/arm/v7') export GOARCH=arm GOARM=7 ;;
  'linux/arm64') export GOARCH=arm64 ;;
  *) echo "Unsupported target: $TARGETPLATFORM" && exit 1 ;;
esac
CGO_ENABLED=0 go build -ldflags='-w -s' -o /WatchYourLAN ./cmd/WatchYourLAN
```
Let me know if you'd prefer to use that instead.